### PR TITLE
Silent refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@material-ui/core": "^4.11.4",
         "@material-ui/icons": "^4.11.2",
         "@reduxjs/toolkit": "^1.6.0",
+        "axios": "^0.21.1",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
@@ -3846,6 +3847,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -7566,7 +7575,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
       "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -20236,6 +20244,14 @@
       "integrity": "sha512-99FZt8qS/xukgxU/8daV8WT7wAakqBzt6lF3XCweO6pwcf50/NgxxBj6ZC7/ejR+F4PWeFpkb9lAMH3y2quBXA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -23147,8 +23163,7 @@
     "follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "dev": true
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@reduxjs/toolkit": "^1.6.0",
+    "axios": "^0.21.1",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/src/api/docs/swagger.json
+++ b/src/api/docs/swagger.json
@@ -357,7 +357,7 @@
               }
             }
           },
-          "400": {
+          "401": {
             "description": "Refresh token regeneration failed.",
             "content": {
               "application/json": {
@@ -378,7 +378,7 @@
                     "type": "SOCIALLY",
                     "code": "INVALID_REFRESH_TOKEN",
                     "message": "Invalid refresh token or token not found!",
-                    "statusCode": 400
+                    "statusCode": 401
                   },
                   "success": false
                 }

--- a/src/api/v1/account/account.controller.js
+++ b/src/api/v1/account/account.controller.js
@@ -63,7 +63,6 @@ function refreshToken(req, res, next) {
     !req.hasOwnProperty('cookies') &&
     !req.cookies.hasOwnProperty('refreshToken')
   ) {
-    // eslint-disable-next-line no-throw-literal
     throw new ApplicationError(AccountError.INVALID_REFRESH_TOKEN);
   }
 

--- a/src/api/v1/account/account.errors.js
+++ b/src/api/v1/account/account.errors.js
@@ -36,6 +36,6 @@ module.exports = {
     type: ApplicationError.type.SOCIALLY,
     code: 'INVALID_REFRESH_TOKEN',
     message: 'Invalid refresh token or token not found!',
-    statusCode: 400,
+    statusCode: 401,
   },
 };

--- a/src/public/js/components/App/App.jsx
+++ b/src/public/js/components/App/App.jsx
@@ -15,6 +15,7 @@ import Register from '../Register';
 import ProtectedRoute from '../ProtectedRoute/ProtectedRoute';
 import { autoLogin } from '../../redux/AuthSlice';
 import VerifyEmail from '../VerifyEmail';
+import axiosSetup from '../../helpers/axiosSetup';
 
 function AppDashboard() {
   return (
@@ -34,6 +35,9 @@ export default function App() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    // setup axios interceptors
+    axiosSetup();
+
     const jwtToken = localStorage.getItem('jwtToken');
     if (!user && jwtToken) dispatch(autoLogin(jwtToken));
   }, []);

--- a/src/public/js/components/VerifyEmail/VerifyEmail.jsx
+++ b/src/public/js/components/VerifyEmail/VerifyEmail.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import { userService } from '../../services/userService';
+import routes from '../../config/routes';
+import { setNotification } from '../../redux/NotificationSlice';
 
 function useQuery() {
   return new URLSearchParams(useLocation().search);
@@ -9,6 +12,7 @@ function useQuery() {
 
 function VerifyEmail() {
   const [verified, setVerified] = useState(false);
+  const dispatch = useDispatch();
 
   const query = useQuery();
   const token = query.get('token');
@@ -18,14 +22,14 @@ function VerifyEmail() {
 
     userService
       .verifyEmail(token)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('Could not verify email.');
-        }
-        return response.json();
-      })
       .then(() => {
         setVerified(true);
+        dispatch(
+          setNotification({
+            message: 'Email verified. You can login now.',
+            isError: false,
+          }),
+        );
       })
       .catch(() => {
         setVerified(false);
@@ -36,6 +40,9 @@ function VerifyEmail() {
     <>
       <div>token: {token}</div>
       <div>Email verification status: {JSON.stringify(verified)}</div>
+      <div>
+        <Link to={`${routes.login}`}>Login</Link>
+      </div>
     </>
   );
 }

--- a/src/public/js/helpers/axiosSetup.js
+++ b/src/public/js/helpers/axiosSetup.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-underscore-dangle */
+import axios from 'axios';
+import { userService } from '../services/userService';
+
+export default function axiosSetup() {
+  axios.interceptors.request.use(
+    (conf) => {
+      const token = localStorage.getItem('jwtToken');
+
+      if (token) {
+        // eslint-disable-next-line no-param-reassign
+        conf.headers.Authorization = `Bearer ${token}`;
+      }
+      return conf;
+    },
+    (error) => Promise.reject(error),
+  );
+
+  axios.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const originalRequest = error.config;
+      if (
+        error.response &&
+        error.response.status === 401 &&
+        error.config &&
+        !error.config._retry
+      ) {
+        originalRequest._retry = true;
+
+        return userService
+          .refreshToken()
+          .then((res) => {
+            const { jwtToken } = res.data.data;
+            localStorage.setItem('jwtToken', jwtToken);
+
+            return axios(originalRequest);
+          })
+          .catch((err) => {
+            Promise.reject(err);
+          });
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}

--- a/src/public/js/redux/AuthSlice.js
+++ b/src/public/js/redux/AuthSlice.js
@@ -25,7 +25,7 @@ const register = createAsyncThunk(
         password,
         confirmPassword,
       });
-      const { data, message } = await response.data;
+      const { data, message } = response.data;
 
       // send success feedback
       dispatch(setNotification({ message, isError: false }));
@@ -73,7 +73,7 @@ const login = createAsyncThunk(
 
 const autoLogin = createAsyncThunk(
   'auth/autoLogin',
-  async (jwtToken, { rejectWithValue, dispatch }) => {
+  async (jwtToken, { rejectWithValue }) => {
     try {
       const response = await userService.autoLogin(jwtToken);
       const { data } = await response.data;
@@ -82,12 +82,6 @@ const autoLogin = createAsyncThunk(
     } catch (err) {
       const { message } = err.response.data.error;
 
-      dispatch(
-        setNotification({
-          message,
-          isError: true,
-        }),
-      );
       return rejectWithValue(message);
     }
   },

--- a/src/public/js/redux/NotificationSlice.js
+++ b/src/public/js/redux/NotificationSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   message: null,
-  isError: true,
+  isError: false,
   isOpen: false,
 };
 

--- a/src/public/js/services/userService.js
+++ b/src/public/js/services/userService.js
@@ -1,76 +1,56 @@
 /* eslint-disable no-use-before-define */
+import axios from 'axios';
 import config from '../config/config';
 
 // eslint-disable-next-line import/prefer-default-export
 export const userService = { register, login, autoLogin, logout, verifyEmail };
 
 async function register(user) {
-  const reqOptions = {
+  return axios({
     method: 'POST',
-    credentials: 'include', // request browser to set the cookie
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(user),
-  };
-
-  return fetch(`${config.apiUrl}/api/v1/account/register`, reqOptions);
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/register`,
+    data: user,
+  });
 }
 
 async function login(email, password) {
-  const reqOptions = {
+  return axios({
     method: 'POST',
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
-  };
-
-  return fetch(`${config.apiUrl}/api/v1/account/login`, reqOptions);
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/login`,
+    data: { email, password },
+  });
 }
 
 async function autoLogin(token) {
-  const reqOptions = {
+  return axios({
     method: 'POST',
-    credentials: 'include',
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/auto-login`,
     headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-  };
-
-  return fetch(`${config.apiUrl}/api/v1/account/auto-login`, reqOptions);
+  });
 }
 
 async function logout(token) {
   // 'refreshToken' cookie is sent
-  const reqOptions = {
+  return axios({
     method: 'POST',
-    credentials: 'include',
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/revoke-token`,
     headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-  };
-
-  return fetch(`${config.apiUrl}/api/v1/account/revoke-token`, reqOptions);
+  });
 }
 
 async function verifyEmail(emailVerificationToken) {
-  const reqOptions = {
+  return axios({
     method: 'POST',
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ emailVerificationToken }),
-  };
-
-  return fetch(`${config.apiUrl}/api/v1/account/verify-email`, reqOptions);
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/verify-email`,
+    data: { emailVerificationToken },
+  });
 }

--- a/src/public/js/services/userService.js
+++ b/src/public/js/services/userService.js
@@ -3,7 +3,14 @@ import axios from 'axios';
 import config from '../config/config';
 
 // eslint-disable-next-line import/prefer-default-export
-export const userService = { register, login, autoLogin, logout, verifyEmail };
+export const userService = {
+  register,
+  login,
+  autoLogin,
+  logout,
+  verifyEmail,
+  refreshToken,
+};
 
 async function register(user) {
   return axios({
@@ -52,5 +59,13 @@ async function verifyEmail(emailVerificationToken) {
     withCredentials: true, // request browser to set the cookie
     url: `${config.apiUrl}/api/v1/account/verify-email`,
     data: { emailVerificationToken },
+  });
+}
+
+async function refreshToken() {
+  return axios({
+    method: 'POST',
+    withCredentials: true, // request browser to set the cookie
+    url: `${config.apiUrl}/api/v1/account/refresh-token`,
   });
 }


### PR DESCRIPTION
Allow automatic renewal of the user session through refresh token rotation.
- Use axios interceptors to add bearer tokens on every request and for every response check for 401 Unauthorized and try to refresh the token.
- Replace the use of fetch api in favor of axios to use interceptors and make code 'DRY'.